### PR TITLE
Fix restart state

### DIFF
--- a/disc_style.py
+++ b/disc_style.py
@@ -689,6 +689,9 @@ if st.session_state.started:
             st.session_state.pop("answers")
             st.session_state.pop("show_results")
             st.session_state.pop("questions")
+            # Reset main flow flags so the introduction page shows again
+            st.session_state.started = False
+            st.session_state.submitted = False
             st.rerun()
 
 


### PR DESCRIPTION
## Summary
- reset `started` and `submitted` flags when the user restarts the assessment so the intro page shows again

## Testing
- `python -m py_compile disc_style.py`


------
https://chatgpt.com/codex/tasks/task_b_6859117174a8832fa6bef6c77ed5acd7