### PR TITLE
Add 5-choice answer control

### DIFF
--- a/disc_style.py
+++ b/disc_style.py
@@ -81,7 +81,7 @@ if not st.session_state.started:
     #### Instructions:
     - You will be presented with a series of statements.
     - For each statement, indicate how much you agree or disagree using the options provided.
-    - A value of **1** completely disagree, **2** somehow disagree, **3** neutral, **4** somehow agree, **5** completely agree
+    - A value of **1** completely disagree, **2** somewhat disagree, **3** neutral, **4** somewhat agree, **5** completely agree
     - Once you complete the assessment, you'll receive your DISC style profile and a detailed breakdown of your results.
     - Carefully read the descriptions as some of them sound similar but have different meanings.
 
@@ -636,17 +636,16 @@ if st.session_state.started:
                 n = i + 1
                 st.markdown(f"#### {n}) {q['question']}")
                 options = [
-                    "Select an option",
                     "1 - Completely Disagree",
-                    "2 - Somehow Disagree",
+                    "2 - Somewhat Disagree",
                     "3 - Neutral",
-                    "4 - Somehow Agree",
+                    "4 - Somewhat Agree",
                     "5 - Completely Agree",
                 ]
                 selected_option = st.radio(
                     "Choose your response",
                     options=options,
-                    index=0,
+                    index=None,
                     key=f"radio_{i}",
                     horizontal=True,
                 )
@@ -658,15 +657,15 @@ if st.session_state.started:
                 submit_button = st.form_submit_button("**Show My DISC Style**")
 
         if submit_button:
-            if selected_option == "Select an option":
+            if selected_option is None:
                 st.warning("Please select a response to proceed.")
             else:
                 # Map the selected option to a score
                 score_mapping = {
                     "1 - Completely Disagree": 1,
-                    "2 - Somehow Disagree": 2,
+                    "2 - Somewhat Disagree": 2,
                     "3 - Neutral": 3,
-                    "4 - Somehow Agree": 4,
+                    "4 - Somewhat Agree": 4,
                     "5 - Completely Agree": 5,
                 }
                 st.session_state.answers[i] = score_mapping[selected_option]


### PR DESCRIPTION
## Summary
- adjust instructions wording for answer scale
- remove default "Select an option" choice and use five radio options
- ensure a choice is required before moving to the next question

## Testing
- `python -m py_compile disc_style.py`
- `python -m json.tool disc_descriptions.json >/dev/null`
- `python -m json.tool questions.json >/dev/null`


------
https://chatgpt.com/codex/tasks/task_b_68592806f67c832fb6c70f10a055d0ef